### PR TITLE
Added an automatic detector for a WAD's associated README / Text File

### DIFF
--- a/Wadinator/Configuration/Editor.cs
+++ b/Wadinator/Configuration/Editor.cs
@@ -1,0 +1,20 @@
+﻿using Tomlet.Attributes;
+
+namespace Wadinator.Configuration; 
+
+/// <summary>
+/// Contains configuration for text editors.
+/// </summary>
+public class Editor {
+    /// <summary>
+    /// The path to the text editor.
+    /// </summary>
+    [TomlProperty("filename")]
+    public string ExecutableName { get; set; } = "";
+
+    /// <summary>
+    /// The argument passed to the text editor to open the file in read-only mode.
+    /// </summary>
+    [TomlProperty("read-only-arg")]
+    public string ReadOnlyArg { get; set; } = "";
+}

--- a/Wadinator/Configuration/ReadmeTexts.cs
+++ b/Wadinator/Configuration/ReadmeTexts.cs
@@ -1,0 +1,26 @@
+﻿using Tomlet.Attributes;
+
+namespace Wadinator.Configuration;
+
+/// <summary>
+/// Contains the text file finder settings.
+/// </summary>
+public class ReadmeTexts {
+    /// <summary>
+    /// Should Wadinator attempt to search for the WAD's matching text file.
+    /// </summary>
+    [TomlProperty("search-for-text")]
+    public bool SearchForText { get; set; } = true;
+
+    /// <summary>
+    /// Should the matching text file's contents be printed?
+    /// </summary>
+    [TomlProperty("print-contents")]
+    public bool PrintContents { get; set; } = false;
+
+    /// <summary>
+    /// Should the finder attempt to accommodate for D!Zone?
+    /// </summary>
+    [TomlProperty("dzone-compat")]
+    public bool DZoneCompat { get; set; } = true;
+}

--- a/Wadinator/Configuration/WadinatorConfig.cs
+++ b/Wadinator/Configuration/WadinatorConfig.cs
@@ -31,10 +31,10 @@ public class WadinatorConfig {
     public bool UseHeretic { get; set; } = false;
 
     /// <summary>
-    /// Should the matching text file's contents be printed?
+    /// An object containing the text file finder configuration.
     /// </summary>
-    [TomlProperty("print-contents")]
-    public bool PrintContents { get; set; } = false;
+    [TomlProperty("readme-texts")]
+    public ReadmeTexts ReadmeTexts { get; set; } = new();
 
     /// <summary>
     /// An object containing text editor configuration.

--- a/Wadinator/Configuration/WadinatorConfig.cs
+++ b/Wadinator/Configuration/WadinatorConfig.cs
@@ -31,6 +31,12 @@ public class WadinatorConfig {
     public bool UseHeretic { get; set; } = false;
 
     /// <summary>
+    /// An object containing text editor configuration.
+    /// </summary>
+    [TomlProperty("editor")]
+    public Editor Editor { get; set; } = new();
+
+    /// <summary>
     /// An object containing game-specific configuration.
     /// </summary>
     [TomlProperty("games")]

--- a/Wadinator/Configuration/WadinatorConfig.cs
+++ b/Wadinator/Configuration/WadinatorConfig.cs
@@ -31,6 +31,12 @@ public class WadinatorConfig {
     public bool UseHeretic { get; set; } = false;
 
     /// <summary>
+    /// Should the matching text file's contents be printed?
+    /// </summary>
+    [TomlProperty("print-contents")]
+    public bool PrintContents { get; set; } = false;
+
+    /// <summary>
     /// An object containing text editor configuration.
     /// </summary>
     [TomlProperty("editor")]

--- a/Wadinator/Program.cs
+++ b/Wadinator/Program.cs
@@ -52,7 +52,7 @@ static string? GetMatchingTextFile(string path) {
 
     // Attempt to find a matching text file.
     var textFiles = Directory.GetFiles(
-        Path.GetDirectoryName(path) ?? "", 
+        Path.GetDirectoryName(path) ?? "",
         Path.GetFileName(path),
         new EnumerationOptions { MatchCasing = MatchCasing.CaseInsensitive }
     );
@@ -113,7 +113,7 @@ if(args.Length == 0 && string.IsNullOrWhiteSpace(config.DefaultPath)) {
         "    -(no)-log       Enables or disables reading/writing from/to the played file.",
         "    -heretic        Specifies that the WADs in the directory were designed for",
         "                    Heretic.",
-        "    -(no-)find-txt  Enables or disables the finding of a WAD's specified text" +
+        "    -(no-)find-txt  Enables or disables the finding of a WAD's specified text",
         "                    file.",
         ""
     );
@@ -344,7 +344,7 @@ if(game == Game.Heretic) {
             Print(
                 "    21 - MBF21",
                 "",
-                "  When in doubt, check the WAD's readme!"
+                "  When in doubt, check the WAD's readme or text file!"
             );
         }
     }
@@ -352,6 +352,8 @@ if(game == Game.Heretic) {
 
 // Lastly, print if the WAD has a text file.
 if(findText) {
+    Print("");
+
     if(wadTxt != null) {
         if(config.PrintContents) {
             Print(

--- a/Wadinator/Program.cs
+++ b/Wadinator/Program.cs
@@ -40,7 +40,7 @@ static string? GetRandomFile(string path, bool recurse, bool useRngLog) {
     return wadFileList[Random.Shared.Next(wadFileList.Count)];
 }
 
-static string? GetMatchingTextFiles(string path, bool dZoneCompat) {
+static string? GetMatchingTextFile(string path, bool dZoneCompat) {
     // If the path isn't a WAD, something's gone wrong.
     if(!path.EndsWith(".wad", StringComparison.InvariantCultureIgnoreCase)) {
         Print("error: this is not a WAD!");
@@ -66,7 +66,7 @@ static string? GetMatchingTextFiles(string path, bool dZoneCompat) {
 
     // Attempt to find a matching text file, located in either:
     // - [WADDIR]/[WADNAME].TXT
-    // - [WADDIR]/TXT/*/[WADNAME.TXT]
+    // - [WADDIR]/TXT/*/[WADNAME].TXT
     var textFiles = new List<string>(Directory.GetFiles(txtDir, txtName, searchOpts));
     
     // If this also is for D!Zone, look for the text file in the form of [WADDIR]/TXT/[WADNAME]/*.TXT.
@@ -247,7 +247,7 @@ if(Directory.Exists(path)) {
 // Attempt to find the .txt file for the WAD if requested, with D!Zone compatibility if requested.
 string? wadTxt = null;
 if(config.ReadmeTexts.SearchForText) {
-    wadTxt = GetMatchingTextFiles(path, config.ReadmeTexts.DZoneCompat);
+    wadTxt = GetMatchingTextFile(path, config.ReadmeTexts.DZoneCompat);
 }
 
 /**************************

--- a/Wadinator/Program.cs
+++ b/Wadinator/Program.cs
@@ -151,10 +151,11 @@ if(args.Length == 0 && string.IsNullOrWhiteSpace(config.DefaultPath)) {
         "                    Heretic.",
         "    -(no-)find-txt  Enables or disables the finding of a WAD's specified text",
         "                    file.",
-        "    -dzone          Enables D!Zone compatibility when searching for text files.",
-        "                    This means it will search for either:",
+        "    -(no-)dzone     Enables or disables D!Zone compatibility when searching for",
+        "                    text files. This means it will search for either:",
         "                    - [WADDIR]/TEXT/[WADNAME]/[WADNAME].TXT",
         "                    - [WADDIR]/TEXT/[WADNAME]/MINE.TXT ",
+        "                    As well as the directory of the WAD.",
         ""
     );
     return 1;
@@ -162,8 +163,6 @@ if(args.Length == 0 && string.IsNullOrWhiteSpace(config.DefaultPath)) {
 
 // Handle command line parameters as lazily as possible.
 var game = config.UseHeretic ? Game.Heretic : Game.Doom;
-var findText = false;
-var dZoneCompat = false;
 var path = config.DefaultPath;
 foreach(var arg in args) {
     switch(arg) {
@@ -195,17 +194,22 @@ foreach(var arg in args) {
         
         case "-no-ft":
         case "-no-find-txt":
-            findText = false;
+            config.ReadmeTexts.SearchForText = false;
             break;
             
         case "-ft":
         case "-find-txt":
-            findText = true;
+            config.ReadmeTexts.SearchForText = true;
+            break;
+        
+        case "-no-dz":
+        case "-no-dzone":
+            config.ReadmeTexts.DZoneCompat = false;
             break;
         
         case "-dz":
         case "-dzone":
-            dZoneCompat = true;
+            config.ReadmeTexts.DZoneCompat = true;
             break;
 
         default:
@@ -247,8 +251,8 @@ if(Directory.Exists(path)) {
 
 // Attempt to find the .txt file for the WAD if requested, with D!Zone compatibility if requested.
 string? wadTxt = null;
-if(findText) {
-    wadTxt = GetMatchingTextFile(path, dZoneCompat);
+if(config.ReadmeTexts.SearchForText) {
+    wadTxt = GetMatchingTextFile(path, config.ReadmeTexts.DZoneCompat);
 }
 
 /**************************
@@ -397,11 +401,11 @@ if(game == Game.Heretic) {
 }
 
 // Lastly, print if the WAD has a text file.
-if(findText) {
+if(config.ReadmeTexts.SearchForText) {
     Print("");
 
     if(wadTxt != null) {
-        if(config.PrintContents) {
+        if(config.ReadmeTexts.PrintContents) {
             Print(
                 "  The WAD has an associated text file, here is its content:",
                 "",

--- a/Wadinator/Wadinator.toml
+++ b/Wadinator/Wadinator.toml
@@ -18,6 +18,7 @@ use-heretic = false
 # can be customised in the [editor] section below.
 print-contents = false
 
+
 # Text editor settings.
 [editor]
 

--- a/Wadinator/Wadinator.toml
+++ b/Wadinator/Wadinator.toml
@@ -21,8 +21,8 @@ search-for-text = true
 
 # This setting enables or disables D!Zone compatibility, as they store their text files in one of three manners:
 # - Right next to the WAD with the same file name.
-# - In [WADDIR]/TXT/[WADNAME]/WADNAME.TXT.
-# - In [WADDIR]/TXT/[WADNAME]/MINE.TXT.
+# - In [WADDIR]/TXT/*/WADNAME.TXT.
+# - In [WADDIR]/TXT/[WADNAME]/*.TXT.
 # Disabling this should theoretically make the finder faster if you do not need D!Zone compatibility.
 dzone-compat = true
 

--- a/Wadinator/Wadinator.toml
+++ b/Wadinator/Wadinator.toml
@@ -13,6 +13,19 @@ log-rng-results = true
 # the -doom switch. This defaults to false.
 use-heretic = false
 
+# Readme / text file finder settings.
+[readme-texts]
+
+# This setting controls whether readmes / text files are searched for by default.
+search-for-text = true
+
+# This setting enables or disables D!Zone compatibility, as they store their text files in one of three manners:
+# - Right next to the WAD with the same file name.
+# - In [WADDIR]/TXT/[WADNAME]/WADNAME.TXT.
+# - In [WADDIR]/TXT/[WADNAME]/MINE.TXT.
+# Disabling this should theoretically make the finder faster if you do not need D!Zone compatibility.
+dzone-compat = true
+
 # The setting that controls the text file finder's output. If this is set to true, the found text file associated with
 # a WAD will be printed into the console. Otherwise, it will output a command to open it in a given text editor, which
 # can be customised in the [editor] section below.

--- a/Wadinator/Wadinator.toml
+++ b/Wadinator/Wadinator.toml
@@ -13,6 +13,17 @@ log-rng-results = true
 # the -doom switch. This defaults to false.
 use-heretic = false
 
+# The setting that controls the text file finder's output. If this is set to true, the found text file associated with
+# a WAD will be printed into the console. Otherwise, it will output a command to open it in a given text editor, which
+# can be customised in the [text.editor] section below.
+print-contents = false
+
+# Text editor settings.
+[text.editor]
+
+# The path to the editor's executable.
+filename = "vim"
+
 
 # Doom-specific settings.
 [games.doom]

--- a/Wadinator/Wadinator.toml
+++ b/Wadinator/Wadinator.toml
@@ -15,14 +15,17 @@ use-heretic = false
 
 # The setting that controls the text file finder's output. If this is set to true, the found text file associated with
 # a WAD will be printed into the console. Otherwise, it will output a command to open it in a given text editor, which
-# can be customised in the [text.editor] section below.
+# can be customised in the [editor] section below.
 print-contents = false
 
 # Text editor settings.
-[text.editor]
+[editor]
 
-# The path to the editor's executable.
+# The path to the editor's executable. By default, this is "vim".
 filename = "vim"
+
+# Specifies the argument to pass to the editor to open the file in read-only mode. By default, this is "-R".
+read-only-arg = "-R"
 
 
 # Doom-specific settings.

--- a/Wadinator/Wadinator.toml
+++ b/Wadinator/Wadinator.toml
@@ -21,10 +21,10 @@ print-contents = false
 # Text editor settings.
 [editor]
 
-# The path to the editor's executable. By default, this is "vim".
+# The path to the editor's executable.
 filename = "vim"
 
-# Specifies the argument to pass to the editor to open the file in read-only mode. By default, this is "-R".
+# Specifies the argument to pass to the editor to open the file in read-only mode.
 read-only-arg = "-R"
 
 


### PR DESCRIPTION
## What

Added the ability for the Wadinator to detect a WAD's matching text file. Currently limited to text files that match their WAD's name in all but extension. For example: `gd.wad` and `gd.txt` match, but `some.wad` and `something.txt` does not.

- Can be configured to either print a command line to open an editor in read-only mode with the text file open, or to print out the whole contents of the text file in console.
- Editors can be configured fully in `Wadinator.toml`.

## Why

It seemed like a nice convenience feature that matches the suggested game command line feature to remove some manual work from the user when looking for readmes / text files associated with a WAD picked by the Wadinator, especially in very populated WAD directories.
