### PR TITLE
Improved Deathmatch Map Detection

### DIFF
--- a/Wadinator/AnalysisResults.cs
+++ b/Wadinator/AnalysisResults.cs
@@ -21,6 +21,9 @@ public record AnalysisResults {
 
     /// <summary>A list of maps lumps contained in this WAD.</summary>
     public List<WadDirectoryEntry> MapList { get; }
+    
+    /// <summary>A list of maps lumps that do not have an exit.</summary>
+    public List<WadDirectoryEntry> MapsWithNoExit { get; }
 
     /// <summary>A list of music lumps contained in this WAD.</summary>
     public List<WadDirectoryEntry> MusicList { get; }
@@ -38,6 +41,7 @@ public record AnalysisResults {
     /// <param name="HasMismatchedBosses"><c>true</c> if this WAD contains Cyberdemon(s) or Spider Mastermind(s), as well as sectors with
     /// tag 666, in E1M8.</param>
     /// <param name="MapList">A list of maps lumps contained in this WAD.</param>
+    /// <param name="MapsWithNoExit">A list of maps lumps that do not have an exit.</param>
     /// <param name="MusicList">A list of music lumps contained in this WAD.</param>
     /// <param name="IsDeathmatchWad"><c>true</c> if this WAD is flagged as a deathmatch WAD. This will be set to <c>false</c> if
     /// deathmatch WAD detection is disabled, or if the check returns negative.</param>
@@ -46,6 +50,7 @@ public record AnalysisResults {
                            bool ContainsMapXxMaps,
                            bool HasMismatchedBosses,
                            List<WadDirectoryEntry> MapList,
+                           List<WadDirectoryEntry> MapsWithNoExit,
                            List<WadDirectoryEntry> MusicList,
                            bool IsDeathmatchWad) {
         this.CompLevel = CompLevel;
@@ -53,6 +58,7 @@ public record AnalysisResults {
         this.ContainsMapXxMaps = ContainsMapXxMaps;
         this.HasMismatchedBosses = HasMismatchedBosses;
         this.MapList = MapList;
+        this.MapsWithNoExit = MapsWithNoExit;
         this.MusicList = MusicList;
         this.IsDeathmatchWad = IsDeathmatchWad;
     }
@@ -73,15 +79,16 @@ public record AnalysisResults {
     /// <summary>
     /// Returns a formatted list of maps.
     /// </summary>
+    /// <param name="mapList">A list of <see cref="WadDirectoryEntry"/> objects that represent the maps to format.</param>
     /// <param name="padding">The number of spaces of padding to put before each line.</param>
     /// <returns>A string containing a formatted list of maps.</returns>
-    public string GetFormattedMapList(int padding) {
+    public string GetFormattedMapList(List<WadDirectoryEntry> mapList, int padding = 0) {
         StringBuilder output = new();
         var pad = new string(' ', padding);
         
         if(ContainsExMxMaps) {
             // Put each episode on its own line.
-            var prefixes = MapList.Select(x => x.Name)
+            var prefixes = mapList.Select(x => x.Name)
                                   .Where(x => x.StartsWith("E"))
                                   .Select(x => x[..2])
                                   .Distinct()
@@ -89,7 +96,7 @@ public record AnalysisResults {
 
             foreach(var prefix in prefixes) {
                 // Find the maps in each episode, trim the strings to remove any excess junk, and display them in a nice list.
-                var episodeMaps = MapList.Select(x => x.Name)
+                var episodeMaps = mapList.Select(x => x.Name)
                                          .Where(x => x.StartsWith(prefix))
                                          .Select(x => x[..4])
                                          .Distinct()
@@ -102,7 +109,7 @@ public record AnalysisResults {
 
         if(ContainsMapXxMaps) {
             // Put each "episode" (10 map set) on its own line.
-            var prefixes = MapList.Select(x => x.Name)
+            var prefixes = mapList.Select(x => x.Name)
                                   .Where(x => x.StartsWith("MAP"))
                                   .Select(x => AdjustDoom2MapNameForEpisodeSort(x)[..4])
                                   .Distinct()
@@ -110,7 +117,7 @@ public record AnalysisResults {
 
             foreach(var prefix in prefixes) {
                 // Find the maps in each "episode," trim the strings down to remove any excess junk, and display them in a nice list.
-                var episodeMaps = MapList.Select(x => x.Name)
+                var episodeMaps = mapList.Select(x => x.Name)
                                          .Where(x => AdjustDoom2MapNameForEpisodeSort(x).StartsWith(prefix))
                                          .Select(x => x[..5])
                                          .Distinct()
@@ -121,6 +128,6 @@ public record AnalysisResults {
             }
         }
 
-        return output.ToString();
+        return output.ToString().TrimEnd();  // Trim away any trailing newlines.
     }
 }

--- a/Wadinator/Analyzer.cs
+++ b/Wadinator/Analyzer.cs
@@ -31,7 +31,7 @@ public class Analyzer {
     }
 
     /// <summary>
-    /// Initializes the wad analyzer.
+    /// Initializes the WAD analyzer.
     /// </summary>
     /// <param name="wadReader">A <see cref="WadReader"/> containing a loaded WAD.</param>
     /// <param name="analysisSettings">Settings for the WAD analyzer.</param>

--- a/Wadinator/Analyzer.cs
+++ b/Wadinator/Analyzer.cs
@@ -116,14 +116,25 @@ public class Analyzer {
     /// <returns><c>true</c> if the WAD is determined to be a deathmatch WAD, otherwise <c>false</c>.</returns>
     private bool DetectDeathmatchWad() {
         var thingLumps = _wad.Lumps.Where(x => x.Name == "THINGS");
+        
         var totalEnemyCount = 0;
 
         foreach(var thingLump in thingLumps) {
-            var thingStream = _wad.GetLump(thingLump);
-            totalEnemyCount += Lumpalyzer.GetEnemyCount(thingStream, _analysisSettings.IsHeretic);
+            // Check for a player start.
+            if(!Lumpalyzer.HasPlayer1Start(_wad.GetLump(thingLump))) {
+                // This WAD will not be fully playable in single-player. Abort here.
+                return true;
+            }
+
+            // Check enemy count.
+            totalEnemyCount += Lumpalyzer.GetEnemyCount(_wad.GetLump(thingLump), _analysisSettings.IsHeretic);
         }
 
-        return _analysisSettings.DeathmatchMapEnemyThreshold >= totalEnemyCount;
+        if(_analysisSettings.DeathmatchMapEnemyThreshold >= totalEnemyCount) {
+            return true;
+        };
+
+        return false;
     }
 
     /// <summary>

--- a/Wadinator/Analyzer.cs
+++ b/Wadinator/Analyzer.cs
@@ -11,9 +11,10 @@ public class Analyzer {
     private AnalysisSettings _analysisSettings;
 
     // Map List Regex
-    private static readonly Regex AllMapsRegEx = new("^(E.M.|MAP..)");
-    private static readonly Regex EpisodeAndMapRegEx = new("^(E.M.)");
-    private static readonly Regex UltimateDoomMapRegEx = new Regex("^(E4M.)");
+    private static readonly Regex AllMapsRegEx = new(@"^(E\dM\d|MAP\d\d).*");
+    private static readonly Regex EpisodeAndMapRegEx = new(@"^(E\dM\d).*");
+    private static readonly Regex UltimateDoomMapRegEx = new Regex(@"^(E4M\d).*");
+    private static readonly Regex MapRegex = new(@"^MAP\d\d.*");
 
     // Map Lump Information
     private List<WadDirectoryEntry> MapList =>
@@ -21,7 +22,7 @@ public class Analyzer {
 
     private bool HasUltimateDoomMaps => MapList.Any(map => UltimateDoomMapRegEx.IsMatch(map.Name));
     private bool UsesEpisodeAndMap => MapList.Any(x => EpisodeAndMapRegEx.IsMatch(x.Name));
-    private bool UsesMapOnly => MapList.Any(x => x.Name.StartsWith("MAP"));
+    private bool UsesMapOnly => MapList.Any(x => MapRegex.IsMatch(x.Name));
     
     // Map Lump Directory Entries
     private struct MapLumpCollection {

--- a/Wadinator/Configuration/Analysis.cs
+++ b/Wadinator/Configuration/Analysis.cs
@@ -30,4 +30,11 @@ public class Analysis {
     /// </summary>
     [TomlProperty("record-skipped-maps")]
     public bool RecordSkippedMaps { get; set; } = false;
+
+    /// <summary>
+    /// If this is set to <c>true</c>, a message will be displayed when a map or maps
+    /// lack a way for the player to exit the level.
+    /// </summary>
+    [TomlProperty("report-maps-with-no-exit")]
+    public bool ReportMapsWithNoExit { get; set; } = true;
 }

--- a/Wadinator/Lumpalyzer.cs
+++ b/Wadinator/Lumpalyzer.cs
@@ -345,6 +345,24 @@ public static class Lumpalyzer {
         ReadThings(thingStream).Any(x => x.Type == Player1StartId);
 
     /// <summary>
+    /// Searches a LINEDEFS lump for a linedef with the given type ID.
+    /// </summary>
+    /// <param name="linedefStream">A <see cref="Stream"/> pointing to the level's LINEDEFS lump.</param>
+    /// <param name="linedefType">A linedef type to search for.</param>
+    /// <returns><c>true</c> if at least one linedef of the given type has been found, otherwise <c>false</c>.</returns>
+    public static bool LinedefTypeExists(Stream linedefStream, ushort linedefType) =>
+        LinedefTypeExists(linedefStream, new List<ushort> { linedefType });
+
+    /// <summary>
+    /// Searches a LINEDEFS lump for a linedef with the given type ID.
+    /// </summary>
+    /// <param name="linedefStream">A <see cref="Stream"/> pointing to the level's LINEDEFS lump.</param>
+    /// <param name="linedefTypes">A list of linedef types to search for.</param>
+    /// <returns><c>true</c> if at least one of the given linedefs has been found, otherwise <c>false</c>.</returns>
+    public static bool LinedefTypeExists(Stream linedefStream, List<ushort> linedefTypes) =>
+        ReadLinedefs(linedefStream).Any(x => linedefTypes.Contains(x.Type));
+
+    /// <summary>
     /// Reads a LINEDEFS lump into a list of <see cref="Linedef"/> records.
     /// </summary>
     /// <param name="linedefStream">A <see cref="Stream"/> pointing to the level's LINEDEFS lump.</param>
@@ -413,4 +431,62 @@ public static class Lumpalyzer {
 
         return things;
     }
+
+    /// <summary>
+    /// Returns whether or not a sector type could be found.
+    /// </summary>
+    /// <param name="sectorStream">A <see cref="Stream"/> pointing to the level's SECTORS lump.</param>
+    /// <param name="sectorType">A sector type to search for.</param>
+    /// <param name="bitwiseComparison">If <c>true</c>, the <paramref name="sectorType"/> field will be treated
+    /// as a bitfield. This is useful for generalized parameters.</param>
+    /// <returns><c>true</c> if at least one of the given sector type exists, otherwise <c>false</c>.</returns>
+    public static bool SectorTypeExists(Stream sectorStream, ushort sectorType, bool bitwiseComparison = false) => 
+        SectorTypeExists(sectorStream, new List<ushort> { sectorType }, bitwiseComparison);
+
+    /// <summary>
+    /// Returns whether or not a sector type could be found.
+    /// </summary>
+    /// <param name="sectorStream">A <see cref="Stream"/> pointing to the level's SECTORS lump.</param>
+    /// <param name="sectorTypes">A list of sector types to search for.</param>
+    /// <param name="bitwiseComparison">If <c>true</c>, the <paramref name="sectorTypes"/> field will be treated
+    /// as a bitfield. This is useful for generalized parameters.</param>
+    /// <returns><c>true</c> if at least one of the given sector types exist, otherwise <c>false</c>.</returns>
+    public static bool SectorTypeExists(Stream sectorStream, List<ushort> sectorTypes, bool bitwiseComparison) {
+        var sectors = ReadSectors(sectorStream);
+
+        if(!bitwiseComparison) {
+            return sectors.Any(x => sectorTypes.Contains(x.Type));  // Easy!
+        }
+
+
+        var result = false;
+        foreach(var sectorType in sectorTypes) {
+            if(result) {
+                // Short-circuit evaluation.
+                return result;
+            }
+
+            result = result || sectors.Any(x => (x.Type & sectorType) == sectorType);
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Checks a thing type and returns whether or not they could be found.
+    /// </summary>
+    /// <param name="thingStream">A <see cref="Stream"/> pointing to the level's THINGS lump.</param>
+    /// <param name="thingType">The thing ID to check for.</param>
+    /// <returns><c>true</c> if at least one of the given thing type exists, otherwise <c>false</c></returns>
+    public static bool ThingTypeExists(Stream thingStream, ushort thingType) =>
+        ThingTypeExists(thingStream, new List<ushort> { thingType });
+    
+    /// <summary>
+    /// Checks a list of thing types and returns whether or not they could be found.
+    /// </summary>
+    /// <param name="thingStream">A <see cref="Stream"/> pointing to the level's THINGS lump.</param>
+    /// <param name="thingTypes">A list of thing IDs to check for.</param>
+    /// <returns><c>true</c> if at least one of the given things exist, otherwise <c>false</c>.</returns>
+    public static bool ThingTypeExists(Stream thingStream, List<ushort> thingTypes) =>
+        ReadThings(thingStream).Any(x => thingTypes.Contains(x.Type));
 }

--- a/Wadinator/Lumpalyzer.cs
+++ b/Wadinator/Lumpalyzer.cs
@@ -6,6 +6,8 @@ namespace Wadinator;
 /// Focuses on reading and analyzes WAD lumps.
 /// </summary>
 public static class Lumpalyzer {
+    private const ushort Player1StartId = 1;
+    
     // ReSharper disable NotAccessedPositionalProperty.Local
     /// <summary>
     /// Represents a Doom or Heretic linedef.
@@ -333,6 +335,14 @@ public static class Lumpalyzer {
 
         return bossFound && tag666Found;
     }
+
+    /// <summary>
+    /// Determines whether or not a things stream contains a player 1 start.
+    /// </summary>
+    /// <param name="thingStream">A <see cref="Stream"/> containing the map's THINGS lump.</param>
+    /// <returns><c>true</c> if the THINGS stream contains a player 1 start, otherwise <c>false</c>.</returns>
+    public static bool HasPlayer1Start(Stream thingStream) =>
+        ReadThings(thingStream).Any(x => x.Type == Player1StartId);
 
     /// <summary>
     /// Reads a LINEDEFS lump into a list of <see cref="Linedef"/> records.

--- a/Wadinator/Program.cs
+++ b/Wadinator/Program.cs
@@ -697,7 +697,7 @@ if(!pathIsDirectory && analysisResults.IsDeathmatchWad) {
     Print(
         "",
         "",
-        $"  NOTE: This WAD contains fewer enemies than the configured threshold ({config.Analysis.SkipDeathmatchThreshold})."
+        "  NOTE: The analyzer has determined that this is a deathmatch WAD."
     );
 }
 

--- a/Wadinator/Program.cs
+++ b/Wadinator/Program.cs
@@ -576,7 +576,8 @@ Print(
     "",
     "  This WAD contains the following maps:",
     "",
-    analysisResults.GetFormattedMapList(4),
+    analysisResults.GetFormattedMapList(analysisResults.MapList, 4),
+    "",
     "",
     "  Here, have a convenient command line:",
     ""
@@ -690,6 +691,17 @@ if(config.ReadmeTexts.SearchForText) {
     } else {
         Print("  The WAD has no associated text file.");
     }
+}
+
+// If the map does not have an exit, print a message.
+if(analysisResults.MapsWithNoExit.Any()) {
+    Print(
+        "",
+        "",
+        "  NOTE: The following maps do not appear to have an exit:",
+        "",
+        analysisResults.GetFormattedMapList(analysisResults.MapsWithNoExit, 4)
+    );
 }
 
 // If the path is not a directory and is detected a deathmatch WAD, print a message.

--- a/Wadinator/Wadinator.toml
+++ b/Wadinator/Wadinator.toml
@@ -56,6 +56,10 @@ skip-deathmatch-threshold = 0
 # If this is set to true, maps that are skipped will be logged into the wadinator_played.txt file.
 record-skipped-maps = false
 
+# If this is set to <c>true</c>, a message will be displayed when a map or maps lack a way for the player to exit
+# the level.
+report-maps-with-no-exit = true
+
 
 # Music randomizer settings.
 [music-randomizer]


### PR DESCRIPTION
Corrects issues detailed in #5.

* Adds check for player 1 start point.
* Adds checks for maps that have no exits (note: this doesn't currently check the DEHACKED lump, so custom enemies that use the A_BrainDie code pointer—like Moonblood's final boss—will fail this check).