### PR TITLE
Corrected issue with map formatter (fixes #10).

### DIFF
--- a/Wadinator/AnalysisResults.cs
+++ b/Wadinator/AnalysisResults.cs
@@ -49,20 +49,22 @@ public record AnalysisResults(
         var pad = new string(' ', padding);
 
         if(ContainsExMxMaps) {
-            // Put each episode on its own line.
-            var prefixes = mapList.Select(x => x.Name)
+            var exmxMaps = mapList.Select(x => x.Name)
                                   .Where(x => x.StartsWith("E"))
-                                  .Select(x => x[..2])
-                                  .Distinct()
-                                  .OrderBy(x => x);
+                                  .ToList();
+
+            // Put each episode on its own line.
+            var prefixes = exmxMaps.Where(x => x.StartsWith("E"))
+                                   .Select(x => x[..2])
+                                   .Distinct()
+                                   .OrderBy(x => x);
 
             foreach(var prefix in prefixes) {
                 // Find the maps in each episode, trim the strings to remove any excess junk, and display them in a nice list.
-                var episodeMaps = mapList.Select(x => x.Name)
-                                         .Where(x => x.StartsWith(prefix))
-                                         .Select(x => x[..4])
-                                         .Distinct()
-                                         .OrderBy(x => x);
+                var episodeMaps = exmxMaps.Where(x => x.StartsWith(prefix))
+                                          .Select(x => x[..4])
+                                          .Distinct()
+                                          .OrderBy(x => x);
 
                 output.Append(pad);
                 output.AppendLine(string.Join(", ", episodeMaps));
@@ -70,20 +72,21 @@ public record AnalysisResults(
         }
 
         if(ContainsMapXxMaps) {
+            var mapXxMaps = mapList.Select(x => x.Name)
+                                   .Where(x => x.StartsWith("MAP"))
+                                   .ToList();
+
             // Put each "episode" (10 map set) on its own line.
-            var prefixes = mapList.Select(x => x.Name)
-                                  .Where(x => x.StartsWith("MAP"))
-                                  .Select(x => AdjustDoom2MapNameForEpisodeSort(x)[..4])
-                                  .Distinct()
-                                  .OrderBy(x => x);
+            var prefixes = mapXxMaps.Select(x => AdjustDoom2MapNameForEpisodeSort(x)[..4])
+                                    .Distinct()
+                                    .OrderBy(x => x);
 
             foreach(var prefix in prefixes) {
                 // Find the maps in each "episode," trim the strings down to remove any excess junk, and display them in a nice list.
-                var episodeMaps = mapList.Select(x => x.Name)
-                                         .Where(x => AdjustDoom2MapNameForEpisodeSort(x).StartsWith(prefix))
-                                         .Select(x => x[..5])
-                                         .Distinct()
-                                         .OrderBy(x => x);
+                var episodeMaps = mapXxMaps.Where(x => AdjustDoom2MapNameForEpisodeSort(x).StartsWith(prefix))
+                                           .Select(x => x[..5])
+                                           .Distinct()
+                                           .OrderBy(x => x);
 
                 output.Append(pad);
                 output.AppendLine(string.Join(", ", episodeMaps));

--- a/Wadinator/Wadinator.csproj
+++ b/Wadinator/Wadinator.csproj
@@ -5,8 +5,8 @@
         <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <AssemblyVersion>1.3.0.0</AssemblyVersion>
-        <FileVersion>1.3.0.0</FileVersion>
+        <AssemblyVersion>1.4.1.0</AssemblyVersion>
+        <FileVersion>1.4.1.0</FileVersion>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
* An exception would be thrown if a WAD contains both Doom and Doom II maps, due to improper filtering being applied on the Doom II map names.
* Bumped assembly/file versions to v1.4.1 (forgot to do that for 1.4.0).